### PR TITLE
Fix typo in light mode button color property

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -138,7 +138,7 @@ body.light-mode .neon-subtext {
 
 body.light-mode .btn {
     border: 2px solid var(--light-neon-blue);
-    color: var(--light-neon-blue);
+    color: var (--light-neon-blue);
 }
 
 .btn:hover {


### PR DESCRIPTION
* Correct the typo in the color property for the light mode button in `styles.css`