### PR TITLE
Fix skill bars in the skills section

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,17 +137,23 @@
                     <h3><i class="fas fa-code"></i> Programming</h3>
                     <div class="skill-bar">
                         <div class="skill-progress" data-percent="85" style="text-align: left;" data-aos="fade-up">
-                            <span><i class="fab fa-python"></i> Python</span>
+                            <div class="skill-name">
+                                <span><i class="fab fa-python"></i> Python</span>
+                            </div>
                         </div>
                     </div>
                     <div class="skill-bar">
                         <div class="skill-progress" data-percent="80" style="text-align: left;" data-aos="fade-up">
-                            <span><i class="fab fa-java"></i> Java</span>
+                            <div class="skill-name">
+                                <span><i class="fab fa-java"></i> Java</span>
+                            </div>
                         </div>
                     </div>
                     <div class="skill-bar">
                         <div class="skill-progress" data-percent="75" style="text-align: left;" data-aos="fade-up">
-                            <span><i class="fab fa-js"></i> JavaScript</span>
+                            <div class="skill-name">
+                                <span><i class="fab fa-js"></i> JavaScript</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -156,17 +162,23 @@
                     <h3><i class="fas fa-brain"></i> AI/ML</h3>
                     <div class="skill-bar">
                         <div class="skill-progress" data-percent="75" style="text-align: right;" data-aos="fade-up">
-                            <span><i class="fas fa-robot"></i> TensorFlow</span>
+                            <div class="skill-name">
+                                <span><i class="fas fa-robot"></i> TensorFlow</span>
+                            </div>
                         </div>
                     </div>
                     <div class="skill-bar">
                         <div class="skill-progress" data-percent="80" style="text-align: right;" data-aos="fade-up">
-                            <span><i class="fas fa-brain"></i> PyTorch</span>
+                            <div class="skill-name">
+                                <span><i class="fas fa-brain"></i> PyTorch</span>
+                            </div>
                         </div>
                     </div>
                     <div class="skill-bar">
                         <div class="skill-progress" data-percent="87" style="text-align: right;" data-aos="fade-up">
-                            <span><i class="fas fa-brain"></i> Scikit-learn</span>
+                            <div class="skill-name">
+                                <span><i class="fas fa-brain"></i> Scikit-learn</span>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -39,9 +39,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // Animate skill bars
   document.querySelectorAll('.skill-progress').forEach(bar => {
     const percent = bar.getAttribute('data-percent');
-    bar.style.width = '0%'; // Reset to 0
+    bar.style.transform = 'translateX(-100%)'; // P54fa
     setTimeout(() => {
-      bar.style.width = percent + '%';
+      bar.style.transform = `translateX(${percent}%)`; // Pb076
     }, 500);
   });
 
@@ -137,9 +137,9 @@ document.addEventListener('DOMContentLoaded', addPlayfulAnimations);
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.skill-progress').forEach(bar => {
     const percent = bar.getAttribute('data-percent');
-    bar.style.width = '0%';
+    bar.style.transform = 'translateX(-100%)'; // P54fa
     setTimeout(() => {
-      bar.style.width = percent + '%';
+      bar.style.transform = `translateX(${percent}%)`; // Pb076
     }, 500);
   });
 });
@@ -193,9 +193,9 @@ document.querySelectorAll('.view-source-btn').forEach(button => {
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.skill-progress').forEach(bar => {
     const percent = bar.getAttribute('data-percent');
-    bar.style.width = '0%';
+    bar.style.transform = 'translateX(-100%)'; // P54fa
     setTimeout(() => {
-      bar.style.width = percent + '%';
+      bar.style.transform = `translateX(${percent}%)`; // Pb076
     }, 500);
   });
 });
@@ -226,9 +226,9 @@ document.querySelector('.btn.nav-btn[href="FinalResume.pdf"]').addEventListener(
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.skill-progress').forEach(bar => {
     const percent = bar.getAttribute('data-percent');
-    bar.style.width = '0%';
+    bar.style.transform = 'translateX(-100%)'; // P54fa
     setTimeout(() => {
-      bar.style.width = percent + '%';
+      bar.style.transform = `translateX(${percent}%)`; // Pb076
     }, 500);
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -286,6 +286,7 @@ body {
     border-radius: 1rem;
     margin: 1.5rem 0;
     position: relative;
+    overflow: hidden; /* Pa8d6 */
 }
 
 .skill-progress {
@@ -296,6 +297,7 @@ body {
     transition: width 2s ease-in-out;
     position: relative;
     animation: skill-animation 2s ease-in-out forwards;
+    transform: translateX(-100%); /* Pce56 */
 }
 
 .skill-progress span {
@@ -306,8 +308,8 @@ body {
 }
 
 @keyframes skill-animation {
-    0% { width: 0; }
-    100% { width: var(--percent); }
+    0% { transform: translateX(-100%); } /* Pe61c */
+    100% { transform: translateX(0); } /* Pe61c */
 }
 
 /* Contact Section */


### PR DESCRIPTION
Update skill bars to use overflow and translate for animation and add skill names to the left side of the bars.

* **styles.css**
  - Add `overflow: hidden;` to `.skill-bar` to prevent overflow.
  - Add `transform: translateX(-100%);` to `.skill-progress` to initially hide the progress bar.
  - Update `@keyframes skill-animation` to use `transform: translateX(0);` for animation.

* **script.js**
  - Update skill bar animation to use `transform: translateX(0);` instead of `width`.
  - Add `transform: translateX(-100%);` to the initial state of the skill progress bar.
  - Add `transform: translateX(${percent}%);` to the final state of the skill progress bar.

* **index.html**
  - Add a `div` with class `skill-name` inside each `skill-progress` div to display the skill name.
  - Update the `span` inside each `skill-progress` div to be a child of the new `div` with class `skill-name`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SanketKumarKar/my-portfolio/pull/44?shareId=3b13efaa-3127-4eb5-9afe-78d2224511f7).